### PR TITLE
include only the used headers and declare the used templates

### DIFF
--- a/orogen/proxies/Task.hpp
+++ b/orogen/proxies/Task.hpp
@@ -18,35 +18,39 @@
 #include <<%= project.typekit.name %>/TaskStates.hpp>
 <% end %>
 
-
-<% task.used_typekits.sort_by(&:name).each do |tk| %>
-  <% next if tk.virtual? %>
-#include <<%= tk.name %>/typekit/Types.hpp>
-<% end %>
-<% task.implemented_classes.sort.each do |class_name, include_file| %>
-#include <<%= include_file %>> // to get <%= class_name %>
-<% end %>
-<% if project.typekit %>
-#include "<%= project.typekit.name %>/typekit/Types.hpp"
+<% task.self_properties.sort_by(&:name).each do |p| %>
+<%   type = p.type %>
+<%=  project.typekit.cxx_gen_includes(*project.typekit.include_for_type(type)) %>
+extern template class RTT::Property< <%= type.cxx_name %> >;
 <% end %>
 
-<%= 
-array = []
-task.each_input_port do |port|
-    array << "extern template class RTT::InputPort< #{port.type.cxx_name} >;\n"
-    array << "extern template class RTT::OutputPort< #{port.type.cxx_name} >;\n"
-end
+<% task.self_attributes.sort_by(&:name).each do |a| %>
+<%   type = a.type %>
+<%=  project.typekit.cxx_gen_includes(*project.typekit.include_for_type(type)) %>
+extern template class RTT::Attribute< <%= type.cxx_name %> >;
+<% end %>
 
-task.each_output_port do |port|
-    array << "extern template class RTT::InputPort< #{port.type.cxx_name} >;\n"
-    array << "extern template class RTT::OutputPort< #{port.type.cxx_name} >;\n"
-end
+<% task.self_ports.sort_by(&:name).each do |p| %>
+<%   type = p.type %>
+<%=  project.typekit.cxx_gen_includes(*project.typekit.include_for_type(type)) %>
+extern template class <%= p.orocos_class %>< <%= type.cxx_name %> >;
+extern template class RTT::base::ChannelElement< <%= type.cxx_name %> >;
+<% end %>
 
-array.uniq!
+<% types = task.self_dynamic_ports.
+        map { |p| [p.orocos_class, p.type] if p.type }.
+        compact %>
+<% types.each do |orocos_class, type| %>
+<%=    project.typekit.cxx_gen_includes(*project.typekit.include_for_type(type)) %>
+extern template class <%= orocos_class %>< <%= type.cxx_name %> >;
+extern template class RTT::base::ChannelElement< <%= type.cxx_name %> >;
+<% end %>
 
-array.join("")
-
-%>
+<% task.self_operations.sort_by(&:name).each do |op| %>
+<%    op.used_types.each do |type| %>
+<%=       project.typekit.cxx_gen_includes(*project.typekit.include_for_type(type)) %>
+<%    end %>
+<% end %>
 
 namespace <%= project.name %> {
 


### PR DESCRIPTION
Including all headers of a certain typekit seems inappropriate.
It also fixes the issue that headers of opaque types might not be included, since they don't end up directly in the Types.hpp of the typekit.

This basically reproduces what happens in orogen when the Task header is generated. Why is it handled so different here?

Note: This is untested but compiles.
