### PR TITLE
Always register extension

### DIFF
--- a/orogen/orogen_plugin.rb
+++ b/orogen/orogen_plugin.rb
@@ -128,9 +128,6 @@ end
 
 class OroGen::Spec::TaskContext
     def cpp_proxies
-        if !find_extension("CPPProxyPlugin")
-            register_extension(CPPProxyPlugin.new)
-            #puts("CPPProxyPlugin active")
-        end
+        register_extension(CPPProxyPlugin.new)
     end
 end


### PR DESCRIPTION
The previous guard was a workaround for a bug in orogen which has been fixed,
 and for subclassing to work as expected, an extensions should always be registered.