### PR TITLE
no duplicates in cflags

### DIFF
--- a/orogen/proxies/proxies.pc
+++ b/orogen/proxies/proxies.pc
@@ -27,11 +27,11 @@ Requires: orocos_cpp_base @<%= project.name.upcase %>_TASKLIB_REQUIRES@ <%= prox
 %>
 Libs:  @RTT_PLUGIN_rtt-typekit_LIBRARY@ @RTT_PLUGIN_rtt-transport-corba_LIBRARY@ @RTT_PLUGIN_rtt-transport-mqueue_LIBRARY@ <%= libs.to_a.sort.join(" ") %> -L${libdir} -l<%= project.name %>-proxies
 <%
-  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.cflags.split(' ') if tk.pkg }.flatten.compact.to_set
-  cflags |= project.used_typekits.map { |tk| tk.pkg.cflags.split(' ') if tk.pkg }.flatten.compact.to_set
+  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
+  cflags |= project.used_typekits.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
 %>
 <% if project.extended_state_support? %>
 <%   cflags << "-I${includedir}/#{project.name}/types" %>
 <% end %>
-Cflags: -I${includedir} <%= cflags.to_a.sort.join(" ") %>
+Cflags: -I${includedir} <%= cflags.to_a.join(" ") %>
 

--- a/orogen/proxies/proxies.pc
+++ b/orogen/proxies/proxies.pc
@@ -27,8 +27,8 @@ Requires: orocos_cpp_base @<%= project.name.upcase %>_TASKLIB_REQUIRES@ <%= prox
 %>
 Libs:  @RTT_PLUGIN_rtt-typekit_LIBRARY@ @RTT_PLUGIN_rtt-transport-corba_LIBRARY@ @RTT_PLUGIN_rtt-transport-mqueue_LIBRARY@ <%= libs.to_a.sort.join(" ") %> -L${libdir} -l<%= project.name %>-proxies
 <%
-  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.cflags if tk.pkg }.compact.to_set
-  cflags |= project.used_typekits.map { |tk| tk.pkg.cflags if tk.pkg }.compact.to_set
+  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.cflags.split(' ') if tk.pkg }.flatten.compact.to_set
+  cflags |= project.used_typekits.map { |tk| tk.pkg.cflags.split(' ') if tk.pkg }.flatten.compact.to_set
 %>
 <% if project.extended_state_support? %>
 <%   cflags << "-I${includedir}/#{project.name}/types" %>


### PR DESCRIPTION
using a lot of proxies resulted in a lot of repeated entries in cflags

tk.pkg.cflags can contain multiple flags in an single string, so split
it before converting to a Set (which removed duplicates)



